### PR TITLE
feat: Add Dockerfile and enable NLTK dependency

### DIFF
--- a/Chatter.py
+++ b/Chatter.py
@@ -229,10 +229,10 @@ try:
     nltk.data.find('tokenizers/punkt')
 except LookupError:
     nltk.download('punkt')
-#try:
-#    nltk.data.find('tokenizers/punkt_tab')
-#except LookupError:
-#    nltk.download('punkt_tab')
+try:
+    nltk.data.find('tokenizers/punkt_tab')
+except LookupError:
+    nltk.download('punkt_tab')
 
 os.environ["CUDA_LAUNCH_BLOCKING"] = "0"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ RUN apt-get update --quiet=2 \
 ENV HOME=$USER_HOME
 RUN if [ $UID -ne 0 ]; then \
       if [ $GID -ne 0 ]; then \
-        addgroup --system --gid $GID app; \
+        groupadd --system --gid $GID app; \
       fi; \
-      adduser --system --no-create-home --uid $UID --gid $GID \
+      useradd --system --uid $UID --gid $GID \
       --home $USER_HOME app; \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+FROM python:3.10-slim
+
+# Set default UID/GID arguments
+ARG UID=0
+ARG GID=0
+ARG USER_HOME=/root
+
+# Set Gradio arguments
+ARG GRADIO_SERVER_PORT=7860
+ARG GRADIO_SERVER_NAME=0.0.0.0
+ARG GRADIO_ANALYTICS_ENABLED=False
+ARG GRADIO_SHARE=False  
+
+RUN apt-get update --quiet=2 \
+  && apt-get upgrade --assume-yes \
+  && apt-get --quiet=2 install --no-install-recommends --assume-yes ffmpeg \
+  && apt-get clean \
+  && rm -rf /var/lib/apt
+
+# Add user/group
+ENV HOME=$USER_HOME
+RUN if [ $UID -ne 0 ]; then \
+      if [ $GID -ne 0 ]; then \
+        addgroup --system --gid $GID app; \
+      fi; \
+      adduser --system --no-create-home --uid $UID --gid $GID \
+      --home $USER_HOME app; \
+    fi
+
+# Handle paths
+RUN mkdir --parents $HOME /app
+RUN chown --recursive $UID:$GID $HOME /app
+
+# Populate environment
+ENV GRADIO_SERVER_PORT=$GRADIO_SERVER_PORT
+ENV GRADIO_SERVER_NAME=$GRADIO_SERVER_NAME
+ENV GRADIO_ANALYTICS_ENABLED=$GRADIO_ANALYTICS_ENABLED
+ENV GRADIO_SHARE=$GRADIO_SHARE
+
+EXPOSE $GRADIO_SERVER_PORT
+
+# Switch user
+USER $UID:$GID
+
+# Configure Python virtual vnvironment
+ENV VIRTUAL_ENV=$HOME/venv
+RUN python -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+WORKDIR /app
+
+# Copy application files
+COPY --chown=$UID:$GID . .
+
+# Install dependencies
+RUN pip install --upgrade pip
+RUN pip install --requirement requirements.txt
+
+# Fix CUDA cudnn path
+ENV LD_LIBRARY_PATH=$VIRTUAL_ENV/lib/python3.10/site-packages/nvidia/cudnn/lib:$VIRTUAL_ENV/lib/python3.10/site-packages/nvidia/cuda_runtime/lib:$LD_LIBRARY_PATH
+
+# Run the app
+CMD ["python", "Chatter.py"]


### PR DESCRIPTION
### Summary
- Added comprehensive Dockerfile to enable containerized deployment with proper user management, environment configuration, and dependency installation
- Enabled CUDA library path configuration for proper GPU acceleration support
- Uncommented and enabled punkt_tab NLTK tokenizer download to ensure proper text processing capabilities with 3.8.2+
- Configured Gradio server settings including port, host, analytics, and sharing options
- Implemented proper file ownership and path management within the container
- Added Python virtual environment setup and dependency installation from requirements.txt
- Set up proper user switching for security best practices in containerized environment
- Included system package installation for ffmpeg support

NLTK reference: nltk/nltk#3293

### Podman non-root example
I prefer to use rootless Podman with a non-root container user building like:

```bash
time podman build -t chatterbox-gradio --no-cache --build-arg="UID=123" --build-arg="GID=123" --build-arg="USER_HOME=/app" .
```

Run with persistent data:

```bash
touch ~/chatterbox-gradio-settings.json
podman run --rm -d --replace -p 127.0.0.1:7860:7860 -v chatterbox-gradio-cache:/app/.cache -v chatterbox-gradio-nltk-data:/app/nltk_data -v ~/chatterbox-gradio-settings.json:/app/settings.json -v ~/audio/output:/app/output --gpus all --name chatterbox-gradio localhost/chatterbox-gradio:latest
```

### Docker root example
I've also tested using root within a Ubuntu 24.04 VM (CPU only). To build:

```bash
time docker build -t chatterbox-gradio --no-cache .
```

Run:

```bash
touch ~/chatterbox-gradio-settings.json
docker run --rm -d -p 127.0.0.1:7860:7860 -v chatterbox-gradio-cache:/root/.cache -v chatterbox-gradio-nltk-data:/root/nltk_data -v ~/chatterbox-gradio-settings.json:/app/settings.json -v ~/audio/output:/app/output --name chatterbox-gradio chatterbox-gradio:latest
```