### PR TITLE
Add multilingual (French) TTS UI + fix installability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,14 @@
 __pycache__
 .mypy_cache/
 .venv/
+.venv-ml/
+
+# Runtime config (auto-generated/overwritten by the app at runtime)
+settings.json
+
+# Generated audio output
+multilingual/outputs/
+*.wav
 
 # VS Code
 *.code-workspace

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -1,0 +1,125 @@
+# 🖥️ Chatterbox-TTS Extended (app anglaise) — Lancement local
+
+Guide d'installation et de lancement en local de l'app principale **`Chatter.py`**
+(TTS anglais + fonctions avancées : candidats, validation Whisper, batch, post-traitement, Voice Conversion).
+
+> Pour la synthèse **multilingue / française**, voir [`multilingual/README.md`](multilingual/README.md).
+> Les deux apps sont indépendantes et peuvent tourner en même temps (ports différents).
+
+---
+
+## 1. Prérequis
+
+- **Python 3.10** (recommandé — les dépendances sont épinglées pour cette version).
+- **FFmpeg** sur le `PATH` (`brew install ffmpeg` sur macOS).
+- GPU **NVIDIA/CUDA** (Linux/Windows) ou **Apple Silicon (MPS)** ou CPU — détecté automatiquement.
+
+L'outil [`uv`](https://github.com/astral-sh/uv) est recommandé pour obtenir un Python 3.10 autonome
+(évite les Python système parfois cassés) :
+
+```bash
+brew install uv        # macOS
+# ou : curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+---
+
+## 2. Installation
+
+Depuis la **racine du projet** :
+
+```bash
+# Environnement Python 3.10 isolé
+uv venv --python 3.10 .venv
+```
+
+### 2a. macOS (Apple Silicon / MPS) ou CPU
+
+Sur Mac il n'y a pas de CUDA : il faut **retirer la ligne de l'index CUDA** de `requirements.txt`
+(sinon `torch==2.7.0+cu128` est introuvable), torch/torchaudio venant alors de PyPI.
+
+```bash
+# Installer les dépendances SANS l'index CUDA (grep retire la ligne à la volée)
+grep -v 'extra-index-url' requirements.txt | .venv/bin/python -m pip install -r /dev/stdin
+
+# librosa 0.10 a besoin de pkg_resources, retiré dans setuptools >= 81
+.venv/bin/python -m pip install "setuptools<81"
+```
+
+### 2b. Linux / Windows (NVIDIA CUDA)
+
+L'index CUDA est nécessaire, on installe donc tel quel :
+
+```bash
+.venv/bin/python -m pip install -r requirements.txt
+.venv/bin/python -m pip install "setuptools<81"
+```
+
+> Le **modèle** est téléchargé automatiquement au premier lancement d'une génération
+> (mis en cache dans `~/.cache/huggingface`, pas de re-téléchargement ensuite).
+
+> ℹ️ `requirements.txt` a été ajusté : `auto-editor` non épinglé (la version `27.1.1` a été retirée
+> de PyPI) et `pydub` ajouté (importé par `Chatter.py`).
+
+---
+
+## 3. Lancement
+
+Depuis la **racine du projet** :
+
+```bash
+# macOS : PYTORCH_ENABLE_MPS_FALLBACK=1 permet aux rares opérations non gérées par MPS
+# de basculer proprement sur CPU au lieu de planter.
+PYTORCH_ENABLE_MPS_FALLBACK=1 .venv/bin/python Chatter.py --port 7860
+```
+
+Puis ouvrir : **http://127.0.0.1:7860**
+
+Options utiles :
+```bash
+.venv/bin/python Chatter.py --port 7860            # choisir le port
+.venv/bin/python Chatter.py --host 0.0.0.0         # exposer sur le réseau local
+.venv/bin/python Chatter.py --share                # lien public Gradio temporaire
+```
+
+---
+
+## 4. Configuration (`settings.json`)
+
+L'app charge ses réglages depuis `settings.json` (racine) au démarrage et les y sauvegarde.
+Une config **équilibrée, optimisée pour Apple Silicon**, y est fournie :
+
+| Paramètre | Valeur | Rôle |
+|---|---|---|
+| Candidats / chunk | **3** | Réduit artefacts/hallucinations |
+| Max attempts | **2** | Retente si la validation échoue |
+| Validation Whisper | **faster-whisper `small`** | Bon compromis précision/vitesse |
+| Workers parallèles | **4** | Adapté à un M1 Pro |
+| CFG Weight | **0.5** | Voix naturelle (1.0 = monotone) |
+| Exaggeration | **0.5** | Émotion neutre |
+| Temperature | **0.8** | Variété maîtrisée |
+| Formats export | **WAV + MP3** | |
+
+Pour aller **plus vite** : baissez les candidats à 1, ou cochez « Bypass Whisper ».
+Pour **plus de qualité** : montez les candidats et le modèle Whisper (`medium`/`large`) — mais c'est plus lent.
+
+---
+
+## 5. Dépannage
+
+| Problème | Solution |
+|---|---|
+| `torch==2.7.0+cu128 ... no wheels ... macosx` | Vous êtes sur Mac : retirez la ligne `--extra-index-url` (voir §2a). |
+| `No module named 'pkg_resources'` | `.venv/bin/python -m pip install "setuptools<81"` |
+| `No module named 'pydub'` | `.venv/bin/python -m pip install pydub` |
+| `auto-editor==27.1.1 ... unsatisfiable` | Version retirée de PyPI ; le `requirements.txt` la laisse désormais non épinglée. |
+| Erreur `pyexpat` / `libexpat` (venv) | Python système cassé : utilisez un Python `uv` (`uv venv --python 3.10 .venv`). |
+| Génération lente | Normal sur CPU/MPS. Réduisez candidats/workers, ou utilisez un modèle Whisper plus petit. |
+
+---
+
+## 6. Performances observées
+
+Testé sur **MacBook Pro M1 Pro (32 Go, MPS)** : device auto-sélectionné `mps`, l'app démarre
+et génère correctement. Sans GPU CUDA, la génération est plus lente qu'un poste NVIDIA — d'où
+la config équilibrée par défaut.

--- a/multilingual/README.md
+++ b/multilingual/README.md
@@ -1,0 +1,109 @@
+# 🌍 Chatterbox Multilingual — Lancement local
+
+Interface Gradio dédiée à la synthèse vocale **multilingue** (23 langues, dont le **français**),
+construite sur le modèle officiel `ChatterboxMultilingualTTS` du package [`chatterbox-tts`](https://pypi.org/project/chatterbox-tts/).
+
+Elle est **volontairement isolée** de l'app anglaise `Chatter.py` :
+- environnement virtuel séparé (`.venv-ml`) pour éviter les conflits de dépendances ;
+- lancée depuis le dossier `multilingual/` pour éviter la collision de nom avec le package local `./chatterbox`.
+
+> ℹ️ L'app anglaise (`Chatter.py`) et cette app multilingue sont **indépendantes** et peuvent tourner en même temps (ports différents).
+
+---
+
+## 1. Prérequis
+
+- **Python 3.10** (recommandé). L'outil [`uv`](https://github.com/astral-sh/uv) est utilisé ici pour gérer un Python autonome et l'environnement.
+- **FFmpeg** sur le `PATH` (`brew install ffmpeg` sur macOS).
+- macOS Apple Silicon (MPS), Linux/Windows CUDA, ou CPU — le device est détecté automatiquement.
+
+Installer `uv` si besoin :
+```bash
+brew install uv        # macOS
+# ou : curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+---
+
+## 2. Installation (première fois)
+
+Depuis la **racine du projet** :
+
+```bash
+# Environnement Python 3.10 isolé pour le multilingue
+uv venv --python 3.10 .venv-ml
+
+# Dépendances (setuptools<81 pour compatibilité librosa/pkg_resources)
+.venv-ml/bin/python -m pip install "setuptools<81" chatterbox-tts
+# (ou, avec uv : uv pip install --python .venv-ml "setuptools<81" chatterbox-tts)
+```
+
+> Le **modèle** (~plusieurs Go) est téléchargé automatiquement au **premier** lancement d'une génération,
+> puis mis en cache dans `~/.cache/huggingface` (aucun re-téléchargement ensuite).
+
+---
+
+## 3. Lancement
+
+Depuis la **racine du projet** :
+
+```bash
+cd multilingual
+../.venv-ml/bin/python app_ml.py
+```
+
+Puis ouvrir : **http://127.0.0.1:7861**
+
+> ⚠️ Toujours lancer depuis le dossier `multilingual/`. Lancer depuis la racine ferait masquer
+> le package `chatterbox` officiel par le dossier local `./chatterbox` (app anglaise).
+
+Pour changer de port, éditez la dernière ligne de `app_ml.py` (`demo.launch(server_port=7861)`).
+
+---
+
+## 4. Utilisation
+
+| Champ | Rôle |
+|---|---|
+| **Texte** | Le texte à synthétiser (2–4 phrases conseillées par génération). |
+| **Langue** | 23 langues ; **français (`fr`)** sélectionné par défaut. |
+| **Voix de référence** *(optionnel)* | Upload/enregistrement de 6–20 s pour **cloner un timbre**. |
+| **Exaggeration** | Intensité émotionnelle (0 = neutre, 2 = très expressif). |
+| **CFG Weight** | Rythme/fidélité. **0.3** = plus vivant ; **0.5** = équilibré. |
+| **Temperature** | Variété de la voix (0.8 par défaut). |
+| **Seed** | 0 = aléatoire ; une valeur fixe = résultat reproductible. |
+
+Les fichiers générés sont enregistrés dans **`multilingual/outputs/`** (format `wav`).
+
+### Langues supportées
+`ar` arabe · `da` danois · `de` allemand · `el` grec · `en` anglais · `es` espagnol · `fi` finnois ·
+`fr` **français** · `he` hébreu · `hi` hindi · `it` italien · `ja` japonais · `ko` coréen · `ms` malais ·
+`nl` néerlandais · `no` norvégien · `pl` polonais · `pt` portugais · `ru` russe · `sv` suédois ·
+`sw` swahili · `tr` turc · `zh` chinois
+
+---
+
+## 5. Conseils français
+
+- Écrivez les **nombres et dates en toutes lettres** (« vingt-trois » plutôt que « 23 ») pour une meilleure prononciation.
+- Pour un ton plus naturel/expressif : **Exaggeration ≈ 0.8**, **CFG Weight ≈ 0.3**.
+- Gardez des passages courts ; cette UI ne fait pas de découpage automatique des longs textes.
+
+---
+
+## 6. Dépannage
+
+| Problème | Solution |
+|---|---|
+| `ModuleNotFoundError: No module named 'chatterbox.mtl_tts'` | Vous avez lancé depuis la racine → le dossier local `./chatterbox` masque le package. Lancez depuis `multilingual/`. |
+| `ModuleNotFoundError: No module named 'pkg_resources'` | `.venv-ml/bin/python -m pip install "setuptools<81"` |
+| Port 7861 déjà utilisé | Changez `server_port` dans `app_ml.py`, ou arrêtez l'ancien process (`pkill -f app_ml.py`). |
+| Génération lente | Normal sur CPU/MPS (~20–25 s / phrase courte sur Apple Silicon M1). Les GPU CUDA sont bien plus rapides. |
+| 1ʳᵉ génération très longue | Téléchargement du modèle en cours (une seule fois). |
+
+---
+
+## 7. Performances observées
+
+Testé sur **MacBook Pro M1 Pro (32 Go, MPS)** : génération d'une phrase française courte en ~20–25 s
+(hors premier téléchargement du modèle). Device sélectionné automatiquement : `mps`.

--- a/multilingual/app_ml.py
+++ b/multilingual/app_ml.py
@@ -1,0 +1,126 @@
+"""
+Chatterbox Multilingual — interface de test (23 langues, dont le français).
+
+Utilise le modèle officiel ResembleAI multilingue (chatterbox.mtl_tts).
+À lancer depuis CE dossier pour éviter le masquage par le package local ./chatterbox :
+    cd multilingual && python app_ml.py
+
+Environnement dédié : ../.venv-ml
+"""
+import os
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+import datetime
+import random
+
+import numpy as np
+import torch
+import torchaudio as ta
+import gradio as gr
+
+from chatterbox.mtl_tts import ChatterboxMultilingualTTS, SUPPORTED_LANGUAGES
+
+# ---- Device (Apple Silicon MPS -> CUDA -> CPU) ----
+if torch.cuda.is_available():
+    DEVICE = "cuda"
+elif torch.backends.mps.is_available():
+    DEVICE = "mps"
+else:
+    DEVICE = "cpu"
+print(f"🚀 Multilingual model running on: {DEVICE}")
+
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "outputs")
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+MODEL = None
+
+
+def get_model():
+    global MODEL
+    if MODEL is None:
+        print("⏳ Chargement du modèle multilingue (téléchargement au 1er lancement)...")
+        MODEL = ChatterboxMultilingualTTS.from_pretrained(DEVICE)
+        print("✅ Modèle chargé.")
+    return MODEL
+
+
+def set_seed(seed: int):
+    torch.manual_seed(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+# Dropdown "fr - French" style, French first
+_lang_items = sorted(SUPPORTED_LANGUAGES.items(), key=lambda kv: (kv[0] != "fr", kv[1]))
+LANG_CHOICES = [(f"{name} ({code})", code) for code, name in _lang_items]
+
+
+def synth(text, language_id, ref_audio, exaggeration, cfg_weight, temperature, seed):
+    if not text or not text.strip():
+        raise gr.Error("Entrez du texte à synthétiser.")
+
+    model = get_model()
+
+    if seed and int(seed) != 0:
+        set_seed(int(seed))
+
+    kwargs = dict(
+        language_id=language_id,
+        exaggeration=float(exaggeration),
+        cfg_weight=float(cfg_weight),
+        temperature=float(temperature),
+    )
+    if ref_audio:
+        kwargs["audio_prompt_path"] = ref_audio
+
+    wav = model.generate(text, **kwargs)
+
+    stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(OUTPUT_DIR, f"{language_id}_{stamp}.wav")
+    ta.save(out_path, wav, model.sr)
+    print(f"💾 Sauvegardé: {out_path}")
+    return out_path
+
+
+with gr.Blocks(title="Chatterbox Multilingual (FR)") as demo:
+    gr.Markdown(
+        "# 🌍 Chatterbox Multilingual\n"
+        "Synthèse vocale multilingue (23 langues). **Français sélectionné par défaut.**\n\n"
+        "> ⚠️ Le tout premier clic télécharge le modèle (~plusieurs Go) — patientez quelques minutes."
+    )
+    with gr.Row():
+        with gr.Column():
+            text = gr.Textbox(
+                label="Texte",
+                lines=6,
+                value="Bonjour ! Ceci est un test de synthèse vocale en français avec le modèle multilingue Chatterbox.",
+            )
+            language_id = gr.Dropdown(
+                choices=LANG_CHOICES, value="fr", label="Langue"
+            )
+            ref_audio = gr.Audio(
+                sources=["upload", "microphone"],
+                type="filepath",
+                label="Voix de référence (optionnel — clonage de timbre, 6–20 s)",
+            )
+            with gr.Row():
+                exaggeration = gr.Slider(0.0, 2.0, value=0.5, step=0.05, label="Exaggeration (émotion)")
+                cfg_weight = gr.Slider(0.0, 1.0, value=0.5, step=0.05, label="CFG Weight (0.3 = plus expressif)")
+            with gr.Row():
+                temperature = gr.Slider(0.05, 2.0, value=0.8, step=0.05, label="Temperature")
+                seed = gr.Number(value=0, precision=0, label="Seed (0 = aléatoire)")
+            btn = gr.Button("🎙️ Générer", variant="primary")
+        with gr.Column():
+            out = gr.Audio(label="Résultat", type="filepath")
+
+    btn.click(
+        synth,
+        inputs=[text, language_id, ref_audio, exaggeration, cfg_weight, temperature, seed],
+        outputs=[out],
+    )
+
+
+if __name__ == "__main__":
+    demo.launch(server_port=7861)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ numpy
 faster-whisper
 openai-whisper
 ffmpeg-python
-auto-editor==27.1.1
+auto-editor
+pydub
 resampy==0.4.3
 librosa==0.10.0
 s3tokenizer


### PR DESCRIPTION
## What changed

### New feature — multilingual TTS UI
- **`multilingual/app_ml.py`**: a standalone Gradio interface built on `ChatterboxMultilingualTTS` (from the official `chatterbox-tts` package) that supports **French + 22 other languages**.
  - Language dropdown (French preselected), optional reference-audio voice cloning, and exaggeration / CFG-weight / temperature / seed controls.
  - Device auto-select: CUDA → Apple Silicon MPS → CPU.
  - Intentionally isolated from the vendored English package (`chatterbox.src.chatterbox`) to avoid the top-level `chatterbox` import-name collision; meant to run from its own directory / virtualenv.

### Installability fixes (universally beneficial)
- **`requirements.txt`**:
  - Unpin `auto-editor` — the pinned `27.1.1` was removed from PyPI, so fresh installs failed to resolve. `auto-editor` is only invoked as an optional CLI subprocess, and the flags used are stable across versions.
  - Add `pydub` — it is imported by `Chatter.py` but was missing from requirements.
  - The CUDA `--extra-index-url` and pinned `torch`/`torchaudio` are left untouched.

### Housekeeping
- **`.gitignore`**: ignore the extra virtualenv, generated audio (`*.wav`, `multilingual/outputs/`) and the runtime-generated `settings.json`.

## Notes for reviewers
- The multilingual UI is additive and does not touch `Chatter.py` or the vendored English model path, so existing behavior is unchanged.
- Tested end-to-end on Apple Silicon (M1 Pro, MPS): French generation works and produces valid audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)